### PR TITLE
Fix: notice検索機能、adminパスワード確認機能を修正

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -394,9 +394,9 @@ class AdminController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        if(!Hash::check($validated['password'], $request->user()->password)) return false;
+        if(!Hash::check($validated['password'], $request->user()->password)) return response()->json(['error' => '비밀번호가 일치하지 않습니다.']);
 
-        return true;
+        return response()->json(['success' => '비밀번호가 일치합니다.']);
     }
 
     /**

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -394,7 +394,7 @@ class AdminController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        if(!Hash::check($validated['password'], $request->user()->password)) return response()->json(['error' => '비밀번호가 일치하지 않습니다.']);
+        if(!Hash::check($validated['password'], $request->user()->password)) return response()->json(['error' => '비밀번호가 일치하지 않습니다.'], 500);
 
         return response()->json(['success' => '비밀번호가 일치합니다.']);
     }

--- a/app/Http/Controllers/Admin/NoticeController.php
+++ b/app/Http/Controllers/Admin/NoticeController.php
@@ -28,10 +28,9 @@ class NoticeController extends Controller
      *         @OA\MediaType(
      *         mediaType="application/json",
      *             @OA\Schema (
-     *                 @OA\Property (property="search_by", type="string", description="검색 구분(tag or title)", example="tag"),
      *                 @OA\Property (property="page", type="integer", description="페이지", example=1),
-     *                 @OA\Property (property="", type="integer", description="페이지", example=1),
-     *                 @OA\Property (property="keyword", type="string", description="검색어", example="엄준식")
+     *                 @OA\Property (property="tag", type="string", description="태그", example="Bus"),
+     *                 @OA\Property (property="title", type="string", description="검색어", example="엄준식")
      *             )
      *         )
      *     ),

--- a/app/Http/Controllers/Admin/NoticeController.php
+++ b/app/Http/Controllers/Admin/NoticeController.php
@@ -30,6 +30,7 @@ class NoticeController extends Controller
      *             @OA\Schema (
      *                 @OA\Property (property="search_by", type="string", description="검색 구분(tag or title)", example="tag"),
      *                 @OA\Property (property="page", type="integer", description="페이지", example=1),
+     *                 @OA\Property (property="", type="integer", description="페이지", example=1),
      *                 @OA\Property (property="keyword", type="string", description="검색어", example="엄준식")
      *             )
      *         )
@@ -42,9 +43,9 @@ class NoticeController extends Controller
     {
         try {
             $validated = $request->validate([
-                'search_by' => ['required', Rule::in(['tag', 'title'])],
+                'tag' => [Rule::in($this->tagRules)],
+                'title' => 'string',
                 'page' => 'required|numeric',
-                'keyword' => 'string',
             ]);
         } catch (ValidationException $validationException) {
             $errorStatus = $validationException->status;
@@ -52,7 +53,17 @@ class NoticeController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        $notices = Notice::where($validated['search_by'], 'LIKE', "%{$validated['keyword']}%")->paginate(10);
+        $notices = Notice::query();
+
+        if(isset($validated['tag'])) {
+            $notices = $notices->where('tag', $validated['tag']);
+        }
+
+        if(isset($validated['title'])) {
+            $notices = $notices->where('title', 'LIKE', "%{$validated['title']}%");
+        }
+
+        $notices = $notices->paginate(10);
 
         return response()->json(['notices' => $notices]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,7 +93,7 @@ Route::middleware(['auth:sanctum', 'abilities:admin'])->group(function () {
             Route::get('/{id}', [NoticeController::class, 'show'])->name('admin.notice.show');
             Route::post('/', [NoticeController::class, 'store'])->name('admin.notice.store');
             Route::patch('/', [NoticeController::class, 'update'])->name('admin.notice.update');
-            Route::get('/{id}', [NoticeController::class, 'destroy'])->name('admin.notice.destroy');
+            Route::delete('/{id}', [NoticeController::class, 'destroy'])->name('admin.notice.destroy');
         });
         Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
         Route::post('/verify-password', [AdminController::class, 'verifyPassword'])->name('admin.verify.pw');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -520,17 +520,17 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
-                                    "search_by": {
-                                        "description": "검색 구분(tag or title)",
-                                        "type": "string",
-                                        "example": "tag"
-                                    },
                                     "page": {
                                         "description": "페이지",
                                         "type": "integer",
                                         "example": 1
                                     },
-                                    "keyword": {
+                                    "tag": {
+                                        "description": "태그",
+                                        "type": "string",
+                                        "example": "Bus"
+                                    },
+                                    "title": {
                                         "description": "검색어",
                                         "type": "string",
                                         "example": "엄준식"


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #189 

## 📝 작업 내용
> 공지사항 검색 기능 수정
> 공지사항 삭제 기능 메서드 DELETE로 수정
> API 문서 수정
> 관리자 비밀번호 확인 기능 수정

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
