### PR TITLE
Fix: 会議室機能の権限とrouteを変更

### DIFF
--- a/app/Http/Controllers/MeetingRoomController.php
+++ b/app/Http/Controllers/MeetingRoomController.php
@@ -120,7 +120,7 @@ class MeetingRoomController extends Controller
      *          @OA\Schema(type="string"),
      *     ),
      *     @OA\Parameter(
-     *          name="roomNumber",
+     *          name="room_number",
      *          description="회의실의 룸 번호",
      *          required=true,
      *          in="query",

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,7 +70,6 @@ Route::middleware(['auth:sanctum', 'abilities:user'])->group(function () {
     });
 
     Route::prefix('meeting-room')->group(function () {
-        Route::get('/check', [MeetingRoomController::class, 'checkReservation'])->name('meeting.check.reservation'); // show 메서드로 인해 먼저 읽혀야함
         Route::prefix('reservation')->group(function () {
             Route::get('/user', [MeetingRoomReservationController::class, 'userIndex'])->name('meeting.reservation.index.user');
             Route::delete('/{id}', [MeetingRoomReservationController::class, 'destroy'])->name('meeting.reservation.destroy');
@@ -140,14 +139,15 @@ Route::middleware(['auth:sanctum', 'ability:user,admin'])->group(function () {
         Route::get('/{id}', [UserAfterServiceController::class, 'show'])->name('as.show');
     });
     Route::prefix('meeting-room')->group(function () {
-        Route::get('/', [MeetingRoomController::class, 'index'])->name('meeting.index');
-        Route::get('/{roomNumber}', [MeetingRoomController::class, 'show'])->name('meeting.show');
-        Route::prefix('reservation')->group(function () {
+        Route::prefix('reservation')->group(function () { // show 메서드로 인해 먼저 나와야함
             Route::get('/', [MeetingRoomReservationController::class, 'index'])->name('meeting.reservation.index');
             Route::get('/{id}', [MeetingRoomReservationController::class, 'show'])->name('meeting.reservation.show');
             Route::post('/', [MeetingRoomReservationController::class, 'store']);
             Route::patch('/{id}', [MeetingRoomReservationController::class, 'reject'])->name('meeting.reservation.reject');
         });
+        Route::get('/check', [MeetingRoomController::class, 'checkReservation'])->name('meeting.check.reservation'); // show 메서드로 인해 먼저 읽혀야함
+        Route::get('/', [MeetingRoomController::class, 'index'])->name('meeting.index');
+        Route::get('/{roomNumber}', [MeetingRoomController::class, 'show'])->name('meeting.show');
     });
 });
 


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) X

## 📝 작업 내용
> 동적 라우트를 후순위로 할당하여 라우팅 에러 해결
> 회의실의 예약 검색 기능을 admin 권한에서도 가능하도록 변경

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
