### PR TITLE
Refactor: 会員情報の修正機能を改善

### DIFF
--- a/app/Http/Controllers/Auth/AdminController.php
+++ b/app/Http/Controllers/Auth/AdminController.php
@@ -306,7 +306,8 @@ class AdminController extends Controller
      *             @OA\Schema (
      *                  @OA\Property (property="name", type="string", description="변경할 이름", example="hyun"),
      *                  @OA\Property (property="phone_number", type="string", description="변경할 휴대폰 번호", example="01012345678"),
-     *                  @OA\Property (property="password", type="string", description="변경할 비밀번호", example="asdf123"),
+     *                  @OA\Property (property="current_password", type="string", description="이전 비밀번호", example="asdf321"),
+     *                  @OA\Property (property="new_password", type="string", description="변경할 비밀번호", example="asdf123"),
      *             )
      *         ),
      *     ),
@@ -318,8 +319,10 @@ class AdminController extends Controller
     {
         try {
             $validated = $request->validate([
-                'name'          => 'string',
-                'phone_number'  => 'string|unique:admins',
+                'name'             => 'string',
+                'phone_number'     => 'string|unique:admins',
+                'current_password' => 'current_password',
+                'new_password'     => 'string|required_with:current_password',
             ]);
         } catch (ValidationException $validationException) {
             $errorStatus = $validationException->status;
@@ -336,9 +339,11 @@ class AdminController extends Controller
             return response()->json(['error' => '해당하는 관리자가 없습니다.'], 404);
         }
 
+        unset($validated['current_password']);
+
         foreach($validated as $key => $value) {
-            if($key == 'password') {
-                $admin->$key = Hash::make($validated['password']);
+            if($key == 'new_password') {
+                $admin->password = Hash::make($validated['new_password']);
             } else {
                 $admin->$key = $value;
             }

--- a/lang/kr/validation.php
+++ b/lang/kr/validation.php
@@ -13,6 +13,7 @@ return [
         'admin_privilege' => '행정 권한',
         'restaurant_privilege' => '식당 권한',
         'approve' => '승인 여부',
+        'new_password' => '새로운 비밀번호',
     ],
     // Type
     'numeric' => ':attribute 은(는) 숫자이어야 합니다.',
@@ -23,11 +24,13 @@ return [
     // rule
     'unique' => '이미 사용 중인 :attribute 입니다.',
     'required' => ':attribute 를 입력해주세요.',
+    'required_with' => ':attribute 를 입력해주세요.',
     'email' => ':attribute 형식을 확인하세요.',
     'in' => ':attribute 의 값은 허용되지 않는 값입니다.',
     'date_format' => ':attribute 값이 날짜(시간) 형식과 일치하지 않습니다.',
     'date' => ':attribute 의 값은 날짜 형식이어야 합니다.',
     'exists' => '해당하는 :attribute 이(가) 존재하지 않습니다.',
+    'current_password' => '기존 비밀번호가 일치하지 않습니다.',
 
 
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1307,7 +1307,12 @@
                                         "type": "string",
                                         "example": "01012345678"
                                     },
-                                    "password": {
+                                    "current_password": {
+                                        "description": "이전 비밀번호",
+                                        "type": "string",
+                                        "example": "asdf321"
+                                    },
+                                    "new_password": {
                                         "description": "변경할 비밀번호",
                                         "type": "string",
                                         "example": "asdf123"
@@ -1747,6 +1752,16 @@
                                         "description": "변경할 휴대폰 번호",
                                         "type": "string",
                                         "example": "01012345678"
+                                    },
+                                    "current_password": {
+                                        "description": "이전 비밀번호",
+                                        "type": "string",
+                                        "example": "asdf321"
+                                    },
+                                    "new_password": {
+                                        "description": "변경할 비밀번호",
+                                        "type": "string",
+                                        "example": "asdf123"
                                     }
                                 },
                                 "type": "object"


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #291 #292 

## 📝 작업 내용
> 관리자 및 유저의 회원정보 수정 로직 중 비밀번호 수정에 대해
기존 비밀번호를 입력받고 확인하여 수정하도록 개선

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
