### PR TITLE
Refactor: ユーザー認証関連機能の修正

### DIFF
--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -126,15 +126,15 @@ class UserController extends Controller
             'name' => $credentials['displayName'],
         ]);
 
-        if (! $token = $this->tokenService->createAccessTokenByModel('users', $user)) {
+        if (! $token = $this->tokenService->createAccessToken('users', $credentials)) {
             return response()->json(['error' => 'Unauthorized'], 401);
         }
-//        $refreshToken = $this->tokenService->createRefreshToken('users', $credentials);
+        $refreshToken = $this->tokenService->createRefreshToken('users', $credentials);
 
         return response()->json([
             'user' => auth('users')->user(),
             'access_token' => $token,
-//            'refresh_token' => $refreshToken,
+            'refresh_token' => $refreshToken,
         ]);
 
     }

--- a/app/Http/Controllers/RefreshController.php
+++ b/app/Http/Controllers/RefreshController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Admin;
+use App\Models\User;
+use App\Services\TokenService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+
+class RefreshController extends Controller
+{
+    public function __construct(protected TokenService $tokenService)
+    {
+    }
+
+    /**
+     * @OA\GET (
+     *     path="/api/refresh",
+     *     tags={"토큰"},
+     *     summary="새 액세스 토큰 발급",
+     *     description="헤더에 리프레쉬 토큰을 포함시켜 요청을 보내면, 해당 토큰을 통해 새 액세스 토큰을 반환",
+     *     @OA\Response(response="200", description="Success"),
+     *     @OA\Response(response="404", description="ModelNotFoundException"),
+     *     @OA\Response(response="500", description="Server Error"),
+     * )
+     */
+    public function __invoke(Request $request)
+    {
+        $guard = $request->grd;
+        $model = null;
+
+        if($guard == 'users') {
+            try {
+                $model = User::findOrFail(auth()->id());
+            } catch (ModelNotFoundException $modelException) {
+                return response()->json(['error' => '해당하는 유저가 없습니다.'], 404);
+            }
+        } else if ($guard == 'admins') {
+            try {
+                $model = Admin::findOrFail(auth()->id());
+            } catch (ModelNotFoundException $modelException) {
+                return response()->json(['error' => '해당하는 관리자가 없습니다.'], 404);
+            }
+        }
+
+
+        return response()->json(['refresh_token' => $this->tokenService->createRefreshTokenByModel($guard, $model)]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
         'api' => [
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class, // Sanctum Middleware
             \Illuminate\Session\Middleware\StartSession::class, // sanctum Middleware
-            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];
@@ -71,5 +71,19 @@ class Kernel extends HttpKernel
         'user.google.approve' => \App\Http\Middleware\UserGoogleApprovedCheck::class,
         'admin.approve' => \App\Http\Middleware\AdminApprovedCheck::class,
         'admin.master' => \App\Http\Middleware\AdminMasterCheck::class,
+        'admin.privilege' => \App\Http\Middleware\Adminprivilege::class,
+        'token.type' => \App\Http\Middleware\TokenType::class,
+    ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * This forces non-global middleware to always be in the given order.
+     *
+     * @var string[]
+     */
+    protected $middlewarePriority = [
+        \App\Http\Middleware\Authenticate::class,
+        \App\Http\Middleware\Adminprivilege::class,
     ];
 }

--- a/app/Http/Middleware/AdminMasterCheck.php
+++ b/app/Http/Middleware/AdminMasterCheck.php
@@ -18,7 +18,7 @@ class AdminMasterCheck
     public function handle(Request $request, Closure $next): Response
     {
         try {
-            $admin = Admin::where('email', $request->email)->firstOrFail();
+            $admin = Admin::findOrFail(auth()->id());
         } catch (ModelNotFoundException $modelException) {
             return response()->json(['error' => '해당하는 관리자가 없습니다.'], 404);
         }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -3,15 +3,27 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
-use Illuminate\Http\Request;
 
 class Authenticate extends Middleware
 {
+
     /**
-     * Get the path the user should be redirected to when they are not authenticated.
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string[]  ...$guards
+     * @return mixed
+     *
      */
-    protected function redirectTo(Request $request): ?string
+    public function handle($request, $next, ...$guards): mixed
     {
-        return $request->expectsJson() ? null : route('login');
+        foreach ($guards as $guard) {
+            if ($this->auth->guard($guard)->check()) {
+                $request->grd = $guard;
+                return $next($request);
+            }
+        }
+        return response()->json(['error' => '인증되지 않은 유저입니다.'], 401);
     }
 }

--- a/app/Http/Middleware/TokenType.php
+++ b/app/Http/Middleware/TokenType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TokenType
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $type = auth()->payload()->get('typ');
+        if($type == 'refresh') {
+            return $next($request);
+        }
+        return response()->json(['error' => 'refresh token이 필요합니다.'], 400);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Auth;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -21,6 +21,12 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->registerPolicies();
+
+        Auth::provider('users', function ($app, array $config) {
+            // Return an instance of Illuminate\Contracts\Auth\CustomUserProvider...
+
+            return new CustomUserProvider();
+        });
     }
 }

--- a/app/Providers/CustomUserProvider.php
+++ b/app/Providers/CustomUserProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Support\Facades\Hash;
+
+class CustomUserProvider implements UserProvider
+{
+    public function retrieveByCredentials(array $credentials)
+    {
+        return User::where('email', $credentials['email'])
+            ->first();
+    }
+
+    public function validateCredentials(Authenticatable $user, array $credentials)
+    {
+        if(isset($credentials['displayName'])) {
+            if(User::where('name', $credentials['displayName'])
+                ->first()) {
+                return true;
+            }
+        } else if(Hash::check($credentials['password'], $user->getAuthPassword())) {
+            return true;
+        }
+        return false;
+    }
+
+    public function retrieveById($identifier)
+    {
+        return User::find($identifier);
+    }
+
+    public function retrieveByToken($identifier, $token)
+    {
+        // TODO: Implement retrieveByToken() method.
+    }
+
+    public function updateRememberToken(Authenticatable $user, $token)
+    {
+        // TODO: Implement updateRememberToken() method.
+    }
+}

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -2,8 +2,7 @@
 
 namespace App\Services;
 
-use App\Models\User;
-use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Model;
 
 class TokenService
 {
@@ -12,13 +11,13 @@ class TokenService
         return auth($guard)->claims(['typ' => 'access'])->attempt($credentials);
     }
 
-    public function createAccessTokenByModel(string $guard, User $user)
-    {
-        return auth($guard)->claims(['typ' => 'access'])->login($user);
-    }
-
     public function createRefreshToken(string $guard, array $credentials)
     {
         return auth($guard)->claims(['typ' => 'refresh'])->setTTL(1440 * 7)->attempt($credentials);
+    }
+
+    public function createRefreshTokenByModel(string $guard, Model $user)
+    {
+        return auth($guard)->claims(['typ' => 'refresh'])->setTTL(1440 * 7)->login($user);
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -69,7 +69,7 @@ return [
             'model'  => App\Models\Admin::class,
         ],
         'users' => [
-            'driver' => 'eloquent',
+            'driver' => 'users',
             'model'  => App\Models\User::class,
         ]
     ],

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -120,7 +120,7 @@ return [
     |
     */
 
-    'refresh_ttl' => env('JWT_REFRESH_TTL', 20160),
+    'refresh_ttl' => env('JWT_REFRESH_TTL', 0),
 
     /*
     |--------------------------------------------------------------------------
@@ -217,7 +217,7 @@ return [
     |
     */
 
-    'blacklist_enabled' => env('JWT_BLACKLIST_ENABLED', true),
+    'blacklist_enabled' => env('JWT_BLACKLIST_ENABLED', false),
 
     /*
     | -------------------------------------------------------------------------

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Auth\UserController;
 use App\Http\Controllers\MeetingRoom\MeetingRoomController;
 use App\Http\Controllers\MeetingRoom\MeetingRoomReservationController;
 use App\Http\Controllers\QRController;
+use App\Http\Controllers\RefreshController;
 use App\Http\Controllers\Restaurant\RestaurantMenusController;
 use App\Http\Controllers\Restaurant\RestaurantSemesterController;
 use App\Http\Controllers\Restaurant\RestaurantWeekendController;
@@ -114,6 +115,10 @@ Route::middleware(['auth:admins'])->group(function () {
 
 // 유저 및 공용
 Route::middleware(['auth:users,admins'])->group(function () {
+    Route::get('/me', function () {
+        return auth('users')->user();
+    });
+    Route::get('/refresh', RefreshController::class);
     Route::prefix('user')->group(function () {
         Route::get('/qr', [QRController::class, 'generator']);
         Route::delete('/',[UserController::class, 'unregister'])->name('user.unregister');

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,7 +118,7 @@ Route::middleware(['auth:users,admins'])->group(function () {
     Route::get('/me', function () {
         return auth('users')->user();
     });
-    Route::get('/refresh', RefreshController::class);
+    Route::get('/refresh', RefreshController::class)->middleware('token.type');
     Route::prefix('user')->group(function () {
         Route::get('/qr', [QRController::class, 'generator']);
         Route::delete('/',[UserController::class, 'unregister'])->name('user.unregister');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1358,19 +1358,19 @@
                 }
             }
         },
-        "/api/admin/master": {
+        "/api/admin/master/{id}": {
             "delete": {
                 "tags": [
                     "관리자"
                 ],
                 "summary": "탈퇴(마스터)",
                 "description": "관리자 탈퇴",
-                "operationId": "5eb9327ee93bbaef99970d22a1de13e1",
+                "operationId": "9aeb249050f344e6dc4e7469cac44213",
                 "parameters": [
                     {
-                        "name": "email",
+                        "name": "id",
                         "in": "path",
-                        "description": "중복을 확인할 관리자의 이메일",
+                        "description": "삭제할 관리자의 아이디",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -1461,6 +1461,11 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
+                                    "admin_id": {
+                                        "description": "관리자 아이디",
+                                        "type": "integer",
+                                        "example": 1
+                                    },
                                     "salon_privilege": {
                                         "description": "미용실 권한",
                                         "type": "boolean",
@@ -2342,6 +2347,27 @@
                     },
                     "422": {
                         "description": "Validation Error"
+                    }
+                }
+            }
+        },
+        "/api/refresh": {
+            "get": {
+                "tags": [
+                    "토큰"
+                ],
+                "summary": "새 액세스 토큰 발급",
+                "description": "헤더에 리프레쉬 토큰을 포함시켜 요청을 보내면, 해당 토큰을 통해 새 액세스 토큰을 반환",
+                "operationId": "3d74351b58466d83188b243bedaa3b1f",
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "404": {
+                        "description": "ModelNotFoundException"
+                    },
+                    "500": {
+                        "description": "Server Error"
                     }
                 }
             }


### PR DESCRIPTION
## 📣 연관된 이슈
> ex) #222 #223 #316

## 📝 작업 내용
> 리다이렉트 대신 에러 메세지를 반환하도록 기존 `authenticate` 미들웨어를 수정하였습니다.
> jwt 설정을 변경하여 액세스 토큰의 리프레쉬를 방지하고, 블랙 리스트를 미사용하도록 하였습니다.
> `CustomUserProvider`를 구현하여 비밀번호가 없을 시, 사용자의 이름으로 인증하도록 구현하였습니다.
> 모든 로그인 로직에 리프레쉬 토큰을 반환하도록 적용하였습니다.
> `ModelNotFoundException`의 에러 메시지를 수정하였습니다.
> 총 관리자 여부를 체크하는 미들웨어를 올바르게 동작하도록 수정하였습니다.
> 리프레쉬 토큰으로 새 토큰을 발급하는 API를 구현하였습니다.
> API 문서를 수정하였습니다.
> 토큰의 타입을 체크하는 미들웨어를 구현하였습니다.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) ~~ 함수 이상한가요?
