### PR TITLE
Refactor: ASのコメント関連機能を実装

### DIFF
--- a/app/Http/Controllers/AfterService/AfterServiceCommentController.php
+++ b/app/Http/Controllers/AfterService/AfterServiceCommentController.php
@@ -17,6 +17,36 @@ class AfterServiceCommentController extends Controller
     {
         return Parent::authorize($ability, $arguments);
     }
+
+    /**
+     * @OA\Get (
+     *     path="/api/after-service/{id}/comment",
+     *     tags={"AS 댓글"},
+     *     summary="특정 AS의 댓글 불러오기",
+     *     description="아이디에 해당하는 AS의 댓글을 받아옵니다.",
+     *     @OA\Parameter(
+     *          name="id",
+     *          description="as의 id",
+     *          required=true,
+     *          in="path",
+     *          @OA\Schema(type="integer"),
+     *     ),
+     *     @OA\Response(response="200", description="Success"),
+     *     @OA\Response(response="500", description="Server Error"),
+     * )
+     */
+    public function show(string $id): \Illuminate\Http\JsonResponse
+    {
+        try {
+            $afterService = AfterService::findOrFail($id);
+        } catch (ModelNotFoundException) {
+            return response()->json(['error' => '해당하는 AS 정보가 없습니다.'], 404);
+        }
+
+        return response()->json(['after_service_comments' => $afterService->afterServiceComments()->get()]);
+
+    }
+
     /**
      * @OA\Post (
      *     path="/api/after-service/{id}/comment",

--- a/app/Http/Controllers/AfterService/AfterServiceController.php
+++ b/app/Http/Controllers/AfterService/AfterServiceController.php
@@ -67,7 +67,8 @@ class AfterServiceController extends Controller
         }
 
         // 클래스의 정의한 연관관계와 함께 불러옴
-        $afterServices = AfterService::query()->with($this->relations);
+        // 유저 정보와 사진만
+        $afterServices = AfterService::query()->with([$this->relations[0], $this->relations[1]]);
 
         if(isset($request['status'])) {
             $afterServices = $afterServices->where('status', $validated['status']);

--- a/app/Http/Controllers/Salon/SalonServiceController.php
+++ b/app/Http/Controllers/Salon/SalonServiceController.php
@@ -126,7 +126,7 @@ class SalonServiceController extends Controller
 
     /**
      * @OA\Patch (
-     *     path="/api/salon/service",
+     *     path="/api/salon/service/{id}",
      *     tags={"미용실 - 서비스"},
      *     summary="서비스 수정(관리자)",
      *     description="미용실의 서비스 정보를 수정 시 사용합니다.",

--- a/app/Models/AfterServiceComment.php
+++ b/app/Models/AfterServiceComment.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class AfterServiceComment extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory;
 
     protected $fillable = [
         'admin_id',

--- a/database/migrations/2024_01_18_081604_create_after_service_comments_table.php
+++ b/database/migrations/2024_01_18_081604_create_after_service_comments_table.php
@@ -16,7 +16,6 @@ return new class extends Migration
             $table->foreignId('admin_id')->constrained()->cascadeOnUpdate()->cascadeOnDelete();
             $table->foreignId('after_service_id')->constrained()->cascadeOnUpdate()->cascadeOnDelete();
             $table->string('comment');
-            $table->softDeletes();
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -156,6 +156,7 @@ Route::middleware(['auth:users,admins', 'token.type:access'])->group(function ()
         Route::get('/', [AfterServiceController::class, 'index'])->name('as.index');
         Route::get('/user', [AfterServiceController::class, 'userIndex'])->name('as.index.user');
         Route::get('/{id}', [AfterServiceController::class, 'show'])->name('as.show');
+        Route::get('/{id}/comment', [AfterServiceCommentController::class, 'show'])->name('as.comment.show');
     });
 
     Route::prefix('meeting-room')->group(function () {
@@ -198,7 +199,7 @@ Route::prefix('restaurant')->group(function () {
     Route::delete('/menu/d/{id}', [RestaurantMenusController::class, 'deleteMenu']);
     Route::delete('/menu/date/d', [RestaurantMenusController::class, 'deleteDate']);
 
-    
+
     Route::post('/semester/p/payment/{id}', [RestaurantSemesterController::class, 'setPayment']);
     Route::get('/weekend/g/payment/{id}', [RestaurantWeekendController::class, 'getPayment']);
     Route::post('/weekend/p/payment/{id}', [RestaurantWeekendController::class, 'setPayment']);
@@ -221,7 +222,7 @@ Route::prefix('restaurant')->group(function () {
     Route::get('/semester/show/user/after', [RestaurantSemesterController::class, 'showUserAfter']);
 
     Route::get('/weekend/show/sum', [RestaurantWeekendController::class, 'sumApply']);
-    
+
 
 
     Route::post('/apply/weekend/auto', [RestaurantApplyDivisionController::class, 'onWeekendAuto']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -926,6 +926,33 @@
             }
         },
         "/api/after-service/{id}/comment": {
+            "get": {
+                "tags": [
+                    "AS 댓글"
+                ],
+                "summary": "특정 AS의 댓글 불러오기",
+                "description": "아이디에 해당하는 AS의 댓글을 받아옵니다.",
+                "operationId": "74eec2920314fff302b3f1fc52a6dee2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "as의 id",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "500": {
+                        "description": "Server Error"
+                    }
+                }
+            },
             "post": {
                 "tags": [
                     "AS 댓글"
@@ -2611,6 +2638,11 @@
                                         "description": "종료 시간",
                                         "type": "string",
                                         "example": "22:00"
+                                    },
+                                    "state": {
+                                        "description": "열림/닫힘",
+                                        "type": "boolean",
+                                        "example": true
                                     }
                                 },
                                 "type": "object"
@@ -2706,6 +2738,11 @@
                                         "description": "종료 날짜",
                                         "type": "string",
                                         "example": "2024-06-22"
+                                    },
+                                    "state": {
+                                        "description": "열림/닫힘",
+                                        "type": "boolean",
+                                        "example": true
                                     }
                                 },
                                 "type": "object"
@@ -2779,7 +2816,7 @@
                                         "type": "string",
                                         "example": "semester or weekend"
                                     },
-                                    "open": {
+                                    "state": {
                                         "description": "열림/닫힘",
                                         "type": "boolean",
                                         "example": "true"
@@ -2820,8 +2857,8 @@
                                         "type": "string",
                                         "example": "semester or weekend"
                                     },
-                                    "open": {
-                                        "description": "열림/닫힘",
+                                    "state": {
+                                        "description": "상태",
                                         "type": "boolean",
                                         "example": "true"
                                     }
@@ -4364,6 +4401,35 @@
                         "description": "ServerError"
                     }
                 }
+            }
+        },
+        "/api/salon/service/{id}": {
+            "delete": {
+                "tags": [
+                    "미용실 - 서비스"
+                ],
+                "summary": "서비스 삭제(관리자)",
+                "description": "미용실 서비스 삭제에 사용됩니다.",
+                "operationId": "fbdeea1998aca5a638b04f05d95d54c5",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "삭제할 서비스의 아이디",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "500": {
+                        "description": "ServerError"
+                    }
+                }
             },
             "patch": {
                 "tags": [
@@ -4371,7 +4437,7 @@
                 ],
                 "summary": "서비스 수정(관리자)",
                 "description": "미용실의 서비스 정보를 수정 시 사용합니다.",
-                "operationId": "7c0f0cd73dc0416cdc9a4dcb0a056a57",
+                "operationId": "55e312867778885f210d484dc04a31cd",
                 "parameters": [
                     {
                         "name": "id",
@@ -4420,35 +4486,6 @@
                     },
                     "422": {
                         "description": "ValidationException"
-                    },
-                    "500": {
-                        "description": "ServerError"
-                    }
-                }
-            }
-        },
-        "/api/salon/service/{id}": {
-            "delete": {
-                "tags": [
-                    "미용실 - 서비스"
-                ],
-                "summary": "서비스 삭제(관리자)",
-                "description": "미용실 서비스 삭제에 사용됩니다.",
-                "operationId": "fbdeea1998aca5a638b04f05d95d54c5",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "삭제할 서비스의 아이디",
-                        "required": true,
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success"
                     },
                     "500": {
                         "description": "ServerError"


### PR DESCRIPTION
## 📣 연관된 이슈
> #395 

## 📝 작업 내용
> 한국어
1. AS 검색 시 댓글을 함께 불러오지 않도록 수정했습니다.
2. AS 아이디를 통해 해당 게시글의 댓글을 불러오는 기능을 구현하였습니다.
3. after_service_comments 테이블 및 모델의 소프트 삭제 기능을 지웠습니다.
4. API 문서 수정



> 일본어
1. AS検索時にコメントを一緒に読み込まないように修正しました。
2. AS IDを使用して、対応する投稿のコメントを読み込む機能を実装しました。
3. after_service_commentsテーブルおよびモデルのソフト削除機能を削除しました。
4. APIドキュメントを修正しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

