### PR TITLE
Feat: 会議室を閉じる機能を実装

### DIFF
--- a/app/Http/Controllers/MeetingRoom/MeetingRoomReservationController.php
+++ b/app/Http/Controllers/MeetingRoom/MeetingRoomReservationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\MeetingRoom;
 
 use App\Http\Controllers\Controller;
+use App\Models\MeetingRoom;
 use App\Models\MeetingRoomReservation;
 use App\Services\ReservedTimeService;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -132,6 +133,16 @@ class MeetingRoomReservationController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
+        // 회의실의 예약 가능 여부 체크
+        try {
+            $meetingRoom = MeetingRoom::findOrFail($validated['meeting_room_number']);
+        } catch (ModelNotFoundException) {
+            return response()->json(['error' => $this->modelExceptionMessage], 404);
+        }
+
+        if(!$meetingRoom->open) return response()->json(['error' => '예약 불가한 회의실입니다.'], 403);
+
+        // 유저 아이디를 받아옴
         $validated['user_id'] = auth('users')->id();
 
         // 기존에 예약된 시간 예외처리

--- a/app/Models/MeetingRoom.php
+++ b/app/Models/MeetingRoom.php
@@ -16,6 +16,7 @@ class MeetingRoom extends Model
 
     protected $fillable = [
         'room_number',
+        'open',
     ];
 
     public function meetingRoomReservations(): \Illuminate\Database\Eloquent\Relations\hasMany

--- a/database/migrations/2024_01_18_072535_create_meeting_rooms_table.php
+++ b/database/migrations/2024_01_18_072535_create_meeting_rooms_table.php
@@ -12,6 +12,7 @@ return new class extends Migration {
     {
         Schema::create('meeting_rooms', function (Blueprint $table) {
             $table->string('room_number', 10)->primary();
+            $table->boolean('open')->default(true);
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -101,6 +101,7 @@ Route::middleware(['auth:admins', 'token.type:access'])->group(function () {
     });
 
     Route::prefix('meeting-room')->group(function () {
+        Route::patch('/{id}', [MeetingRoomController::class, 'close'])->name('meeting.update');
         Route::patch('/reservation/reject/{id}', [MeetingRoomReservationController::class, 'reject'])->name('meeting.reservation.reject');
         Route::post('/', [MeetingRoomController::class, 'store'])->name('meeting.store');
         Route::delete('/{id}', [MeetingRoomController::class, 'destroy'])->name('meeting.destroy');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2342,6 +2342,54 @@
                         "description": "ServerError"
                     }
                 }
+            },
+            "patch": {
+                "tags": [
+                    "회의실"
+                ],
+                "summary": "회의실 상태 변경(관리자)",
+                "description": "회의실을 닫거나 열 때 사용합니다.",
+                "operationId": "ed98368b4d82048f7447deef2e52ab4e",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "변경할 회의실 룸 번호",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "회의실 오픈 여부",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "open": {
+                                        "description": "오픈 여부",
+                                        "type": "boolean",
+                                        "example": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "422": {
+                        "description": "ValidationException"
+                    },
+                    "500": {
+                        "description": "ServerError"
+                    }
+                }
             }
         },
         "/api/meeting-room/reservation": {


### PR DESCRIPTION
## 📣 연관된 이슈
> #402 


## 📝 작업 내용
> 한국어
1. 기존 회의실 테이블을 수정하여 boolean 값을 가지는 open 컬럼을 추가하였습니다.
2. 회의실을 닫는 기능을 구현하였습니다. (수정 기능)
3. API 문서 수정
4. 회의실 예약 기능에 닫혀있는 회의실의 경우에는 예약이 불가하도록 개선하였습니다.


> 일본어
1. 既存の会議室テーブルを変更し、boolean値を持つopen列を追加しました。
2. 会議室を閉鎖する機能を実装しました。（修正機能）
3. APIドキュメントを修正しました。
4. 会議室予約機能において、閉鎖されている会議室の場合は予約できないように改善しました。


## 💬 리뷰 요구사항 (선택)
> 컬럼 이상 없는지 봐 주세요

