### PR TITLE
Fix: approveをチェックするmiddlewareを修正/適用

### DIFF
--- a/app/Http/Middleware/ApproveCheck.php
+++ b/app/Http/Middleware/ApproveCheck.php
@@ -15,14 +15,12 @@ class ApproveCheck
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next, ...$guards): Response
     {
-        $type = auth()->payload()->get('grd');
-
-        $user = auth($type)->user();
-
-        if(!$user->approved) {
-            return response()->json(['error' => '승인되지 않은 유저입니다.'], 403);
+        foreach ($guards as $guard) {
+            if (auth($guard)->check() && !auth($guard)->user()->approved) {
+                return response()->json(['error' => '승인되지 않은 유저입니다.'], 403);
+            }
         }
 
         return $next($request);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -23,6 +23,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
+        // users 가드를 사용할 때 해당 커스텀 프로바이더를 통해 인증함
         Auth::provider('users', function ($app, array $config) {
             // Return an instance of Illuminate\Contracts\Auth\CustomUserProvider...
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -13,6 +13,7 @@ return [
     |
     */
 
+    // policy 때문에 기본 값 admin으로 설정해놓음
     'defaults' => [
         'guard' => 'admins',
         'passwords' => 'users',

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,7 +63,7 @@ Route::prefix('admin')->group(function () {
 });
 
 // 관리자
-Route::middleware(['auth:admins', 'token.type:access'])->group(function () {
+Route::middleware(['auth:admins', 'token.type:access', 'approve:users,admins'])->group(function () {
     Route::prefix('admin')->group(function() {
         Route::get('/', [AdminController::class, 'admin'])->name('admin.info');
         Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
@@ -123,13 +123,13 @@ Route::middleware(['auth:admins', 'token.type:access'])->group(function () {
         Route::patch('/reject/{id}', [AbsenceController::class, 'reject'])->name('absence.reject');
     });
 
-   
+
 });
 
 // 유저 및 공용
-Route::get('/refresh', RefreshController::class)->middleware(['auth:users,admins', 'token.type:refresh']);
+Route::get('/refresh', RefreshController::class)->middleware(['auth:users,admins', 'token.type:refresh', 'approve:users,admins']);
 
-Route::middleware(['auth:users,admins', 'token.type:access'])->group(function () {
+Route::middleware(['auth:users,admins', 'token.type:access', 'approve:users,admins'])->group(function () {
     Route::prefix('user')->group(function () {
         Route::get('/', [UserController::class, 'user'])->name('user.info');
         Route::get('/qr', [QRController::class, 'generator'])->name('qr');
@@ -215,7 +215,7 @@ Route::prefix('restaurant')->group(function () {
     Route::get('/semester/apply', [RestaurantSemesterController::class, 'getRestaurantApply']);
     Route::get('/weekend/apply', [RestaurantWeekendController::class, 'getRestaurantApply']);
 
-    
+
     Route::get('/semester/meal-type/get', [SemesterMealTypeController::class, 'getMealType']);
     Route::get('/weekend/meal-type/get', [WeekendMealTypeController::class, 'getMealType']);
 


### PR DESCRIPTION
## 📣 연관된 이슈
> #407 


## 📝 작업 내용
> 한국어
1. 파라미터로 가드를 받아, 올바르게 사용자를 찾고 approve 컬럼을 검증하도록 구현하였습니다.
2. 인증 관련 로직에 주석을 추가하였습니다.


> 일본어
1. パラメーターとしてガードを受け取り、ユーザーを正しく検索し、承認カラムを検証するように実装しました。
2. 認証関連のロジックにコメントを追加しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

