### PR TITLE
Feat: 管理者のパスワードリセット機能を実装

### DIFF
--- a/app/Mail/ResetPassword.php
+++ b/app/Mail/ResetPassword.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ResetPassword extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+
+    public function __construct(public string $secret)
+    {
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[영진전문대학교 글로벌캠퍼스] 비밀번호 초기화',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.password',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/PasswordResetCode.php
+++ b/app/Models/PasswordResetCode.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PasswordResetCode extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'email';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'email',
+        'code',
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "aws/aws-sdk-php": "^3.301",
         "darkaonline/l5-swagger": "^8.5",
         "google/apiclient": "^2.15",
         "guzzlehttp/guzzle": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1633fc162121d240e8a501cc643b7ee7",
+    "content-hash": "696cc5f64b17e7096444f2bd667b95f5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.299.0",
+            "version": "3.301.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "76d1165568d949b430a87eaa42f6dbc4b6705b6f"
+                "reference": "2fd8cae93e87326f2263c420fa9031ad8903a2f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/76d1165568d949b430a87eaa42f6dbc4b6705b6f",
-                "reference": "76d1165568d949b430a87eaa42f6dbc4b6705b6f",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2fd8cae93e87326f2263c420fa9031ad8903a2f2",
+                "reference": "2fd8cae93e87326f2263c420fa9031ad8903a2f2",
                 "shasum": ""
             },
             "require": {
@@ -151,9 +151,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.299.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.301.7"
             },
-            "time": "2024-02-15T19:08:34+00:00"
+            "time": "2024-03-25T18:14:28+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",

--- a/config/mail.php
+++ b/config/mail.php
@@ -48,6 +48,9 @@ return [
 
         'ses' => [
             'transport' => 'ses',
+           'key' => env('AWS_SES_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SES_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         ],
 
         'postmark' => [

--- a/database/migrations/2024_03_26_161131_create_password_reset_codes_table.php
+++ b/database/migrations/2024_03_26_161131_create_password_reset_codes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('password_reset_codes', function (Blueprint $table) {
+            $table->string('email')->primary();
+            $table->string('code');
+            $table->timestamps();
+            $table->timestamp('expires_at')->nullable();
+        });
+        DB::unprepared(
+            'CREATE TRIGGER set_expires_at BEFORE INSERT ON password_reset_codes
+                   FOR EACH ROW
+                   BEGIN
+                       SET NEW.expires_at = NOW() + INTERVAL 10 MINUTE;
+                   END;'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS set_expires_at');
+        Schema::dropIfExists('reset_password_code');
+    }
+};

--- a/resources/views/mail/password.blade.php
+++ b/resources/views/mail/password.blade.php
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    <link rel="stylesheet" href="/resources/css/app.css">
+</head>
+<body>
+    <div id="header" style="background-color: #2596be; text-align: center; padding: 1.5%">
+        <img src="https://d214004cc270e2.cloudfront.net/school-name.png"  alt="school_logo"/>
+    </div>
+    <div id="content" style="text-align: center; padding: 3%;">
+        <h3>인증번호를 확인해주세요.</h3>
+        <p style="font-size: 2rem"><strong>{{$secret}}</strong></p>
+        <p>비밀번호 초기화를 위한 인증번호입니다. 10분 내에 인증번호를 입력해주세요.</p>
+    </div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,7 +59,8 @@ Route::prefix('admin')->group(function () {
     });
     Route::post('/find-email', [AdminController::class, 'findEmail'])->name('admin.find.email');
     Route::get('/verify-email/{email}', [AdminController::class, 'verifyUniqueAdminEmail'])->name('admin.verify.email');
-//    Route::post('/forgot-password', [AdminController::class, 'forgotPassword'])->middleware('guest')->name('admin.forgot.password');
+    Route::post('/reset-password', [AdminController::class, 'resetPassword'])->name('admin.reset.pw');
+    Route::get('/reset-password/verify', [AdminController::class, 'verifyPasswordResetCode'])->name('admin.reset.pw.verify');
 });
 
 // 관리자


### PR DESCRIPTION
## 📣 연관된 이슈
> #55 


## 📝 작업 내용
> 한국어
1. SES 작업을 위한 aws-sdk를 설치하였습니다.
2. config/mail.php에 SES 관련 설정 추가하였습니다.
3. 메일을 정의하기 위한 클래스 작성하였습니다.
4. 사용자에게 전송될 메일 템플릿을 blade 파일로 작성하였습니다.
5. 비밀번호 초기화 코드를 저장하기 위한 테이블을 추가하였습니다.
6. 비밀번호 초기화 및 검증 기능 구현하였습니다.


> 일본어
1. SESの操作に使用するAWS SDKをインストールしました。
2. config/mail.phpにSES関連の設定を追加しました。
3. メールを定義するためのクラスを作成しました。
4. ユーザーに送信されるメールのテンプレートをBladeファイルで作成しました。
5. パスワードリセットコードを保存するためのテーブルを追加しました。
6. パスワードのリセットおよび検証機能を実装しました。


## 💬 리뷰 요구사항 (선택)
> 마이그레이션 파일 이상 있는지 확인해주세요.
