### PR TITLE
Refactor: パスワードをリセットする機能を改善

### DIFF
--- a/app/Http/Controllers/Auth/AdminController.php
+++ b/app/Http/Controllers/Auth/AdminController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers\Auth;
 
 use App\Exceptions\DestroyException;
 use App\Http\Controllers\Controller;
-use App\Mail\ResetPassword;
 use App\Models\Admin;
-use App\Models\PasswordResetCode;
+use App\Services\ResetPasswordService;
 use App\Services\TokenService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -623,14 +621,8 @@ class AdminController extends Controller
             return response()->json(['error' => '해당하는 관리자가 존재하지 않습니다.'], 404);
         }
 
-        $secret = sprintf('%06d',rand(000000,999999));
+        $resetPasswordService = new ResetPasswordService($validated['email']);
 
-        $validated['code'] = $secret;
-
-        PasswordResetCode::create($validated);
-
-        Mail::to($request['email'])->send(new ResetPassword($secret));
-
-        return response()->json(['message' => '이메일이 발송되었습니다.']);
+        return $resetPasswordService();
     }
 }

--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -4,15 +4,13 @@ namespace App\Http\Controllers\Auth;
 
 use App\Exceptions\DestroyException;
 use App\Http\Controllers\Controller;
-use App\Mail\ResetPassword;
-use App\Models\PasswordResetCode;
 use App\Models\User;
+use App\Services\ResetPasswordService;
 use App\Services\TokenService;
 use Google_Client;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 
@@ -444,14 +442,8 @@ class UserController extends Controller
             return response()->json(['error' => '해당하는 유저가 존재하지 않습니다.'], 404);
         }
 
-        $secret = sprintf('%06d',rand(000000,999999));
+        $resetPasswordService = new ResetPasswordService($validated['email']);
 
-        $validated['code'] = $secret;
-
-        PasswordResetCode::create($validated);
-
-        Mail::to($request['email'])->send(new ResetPassword($secret));
-
-        return response()->json(['message' => '이메일이 발송되었습니다.']);
+        return $resetPasswordService();
     }
 }

--- a/database/migrations/2024_03_26_161131_create_password_reset_codes_table.php
+++ b/database/migrations/2024_03_26_161131_create_password_reset_codes_table.php
@@ -19,12 +19,20 @@ return new class extends Migration
             $table->timestamp('expires_at')->nullable();
         });
         DB::unprepared(
-            'CREATE TRIGGER set_expires_at BEFORE INSERT ON password_reset_codes
+            'CREATE TRIGGER set_expires_at_insert BEFORE INSERT ON password_reset_codes
                    FOR EACH ROW
                    BEGIN
-                       SET NEW.expires_at = NOW() + INTERVAL 10 MINUTE;
+                       SET NEW.expires_at = NOW() + INTERVAL 3 MINUTE;
                    END;'
         );
+        DB::unprepared(
+            'CREATE TRIGGER set_expires_at_update BEFORE UPDATE ON password_reset_codes
+                   FOR EACH ROW
+                   BEGIN
+                       SET NEW.expires_at = NOW() + INTERVAL 3 MINUTE;
+                   END;'
+        );
+
     }
 
     /**
@@ -32,7 +40,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        DB::unprepared('DROP TRIGGER IF EXISTS set_expires_at');
-        Schema::dropIfExists('reset_password_code');
+        DB::unprepared('DROP TRIGGER IF EXISTS set_expires_at_insert');
+        DB::unprepared('DROP TRIGGER IF EXISTS set_expires_at_update');
+        Schema::dropIfExists('reset_password_codes');
     }
 };


### PR DESCRIPTION
## 📣 연관된 이슈
> #55 #415 


## 📝 작업 내용
> 한국어
1. 비밀번호 초기화 코드를 생성하는 부분을 `ResetPasswordService`로 분리하였습니다.
2. `updateOrInsert`를 이용하여 코드 재발급 시에도 유연하게 동작하도록 구현하였습니다.
3. 트리거를 추가하여 `update`에도 `expired_at` 컬럼이 수정되도록 하였습니다.


> 일본어
1. パスワードリセットコードの生成部分を `ResetPasswordService` に分離しました。
2. `updateOrInsert` を使用してコードの再発行時にも柔軟に動作するように実装しました。
3. トリガーを追加して、`update` 時にも `expired_at` カラムが更新されるようにしました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

