### PR TITLE
Feat: パスワードリセットトークンおよびパスワード再設定機能を実装

### DIFF
--- a/app/Http/Controllers/AfterService/AfterServiceController.php
+++ b/app/Http/Controllers/AfterService/AfterServiceController.php
@@ -231,7 +231,7 @@ class AfterServiceController extends Controller
     public function updateStatus(string $id): \Illuminate\Http\JsonResponse
     {
         try {
-            $this->authorize('updateStatus');
+            $this->authorize('admin');
         } catch (AuthorizationException) {
             return $this->denied();
         }

--- a/app/Http/Controllers/Auth/AdminController.php
+++ b/app/Http/Controllers/Auth/AdminController.php
@@ -413,7 +413,7 @@ class AdminController extends Controller
      *     @OA\Response(response="500", description="ServerError"),
      * )
      */
-    public function updateProfile(Request $request): \Illuminate\Http\JsonResponse
+    public function update(Request $request): \Illuminate\Http\JsonResponse
     {
         try {
             $this->authorize('admin');

--- a/app/Http/Controllers/Auth/AdminController.php
+++ b/app/Http/Controllers/Auth/AdminController.php
@@ -188,10 +188,10 @@ class AdminController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        if (!$token = $this->tokenService->createAccessToken($credentials)) {
+        if (!$token = $this->tokenService->generateToken($credentials, 'access')) {
             return response()->json(['error' => '관리자의 이메일 혹은 비밀번호가 올바르지 않습니다.'], 401);
         }
-        $refreshToken = $this->tokenService->createRefreshToken($credentials);
+        $refreshToken = $this->tokenService->generateToken($credentials, 'refresh');
 
         try {
             $admin = User::findOrFail(auth()->id());
@@ -241,10 +241,10 @@ class AdminController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        if (!$token = $this->tokenService->createAccessToken($credentials)) {
+        if (!$token = $this->tokenService->generateToken($credentials, 'access')) {
             return response()->json(['error' => '관리자의 이메일 혹은 비밀번호가 올바르지 않습니다.'], 401);
         }
-        $refreshToken = $this->tokenService->createRefreshToken($credentials);
+        $refreshToken = $this->tokenService->generateToken($credentials, 'refresh');
 
         return response()->json([
             'user' => auth()->user(),

--- a/app/Http/Controllers/Auth/RefreshController.php
+++ b/app/Http/Controllers/Auth/RefreshController.php
@@ -35,6 +35,6 @@ class RefreshController extends Controller
             return response()->json(['error' => $this->modelExceptionMessage], 404);
         }
 
-        return response()->json(['refresh_token' => $this->tokenService->createAccessTokenByModel($model)]);
+        return response()->json(['access_token' => $this->tokenService->generateTokenByModel($model, 'access')]);
     }
 }

--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -152,10 +152,10 @@ class UserController extends Controller
             'name' => $credentials['displayName'],
         ]);
 
-        if (!$user || !$token = $this->tokenService->createAccessToken($credentials)) {
+        if (!$user || !$token = $this->tokenService->generateToken($credentials, 'access')) {
             return response()->json(['error' => '토큰 생성에 실패하였습니다.'], 401);
         }
-        $refreshToken = $this->tokenService->createRefreshToken($credentials);
+        $refreshToken = $this->tokenService->generateToken($credentials, 'refresh');
 
         return response()->json([
             'user' => auth()->user(),
@@ -200,11 +200,11 @@ class UserController extends Controller
             return response()->json(['error' => $errorMessage], $errorStatus);
         }
 
-        if (! $token = $this->tokenService->createAccessToken($credentials)) {
+        if (! $token = $this->tokenService->generateToken($credentials, 'access')) {
             return response()->json(['error' => '토큰 생성에 실패하였습니다.'], 401);
         }
 
-        $refreshToken = $this->tokenService->createRefreshToken($credentials);
+        $refreshToken = $this->tokenService->generateToken($credentials, 'refresh');
 
         return response()->json([
             'user' => auth()->user(),

--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -405,4 +405,15 @@ class UserController extends Controller
 
         return $resetPasswordService();
     }
+
+    public function recoverPassword(Request $request)
+    {
+        $user = auth()->user();
+
+        $user->password = Hash::make($request->password);
+
+        if(!$user->save()) return response()->json(['error' => '비밀번호 변경에 실패하였습니다.'], 500);
+
+        return response()->json(['message' => '비밀번호가 변경되었습니다.']);
+    }
 }

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -6,20 +6,16 @@ use Illuminate\Database\Eloquent\Model;
 
 class TokenService
 {
-    public function createAccessToken(array $credentials)
+    public function generateToken(array $credentials, string $type)
     {
-        return auth()->claims(['typ' => 'access'])->attempt($credentials);
+        if($type == 'refresh') {
+            return auth()->claims(['typ' => 'refresh'])->setTTL(1440 * 7)->attempt($credentials);
+        }
+        return auth()->claims(['typ' => $type])->attempt($credentials);
     }
 
-    public function createAccessTokenByModel(Model $user)
+    public function generateTokenByModel(Model $user, string $type)
     {
-        return auth()->claims(['typ' => 'access'])->login($user);
+        return auth()->claims(['typ' => $type])->login($user);
     }
-
-    public function createRefreshToken(array $credentials)
-    {
-        return auth()->claims(['typ' => 'refresh'])->setTTL(1440 * 7)->attempt($credentials);
-    }
-
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,10 @@ Route::prefix('admin')->group(function () {
     Route::post('/reset-password', [AdminController::class, 'resetPassword'])->name('admin.reset.pw');
 });
 
+// 이메일 타입의 토큰도 허용함
+Route::patch('/user/recover' , [UserController::class, 'recoverPassword'])
+    ->name('user.update')->middleware(['auth:users', 'token.type:email']);
+
 // 토큰 필요
 Route::middleware(['auth:users', 'token.type:access', 'approve:users'])->group(function () {
     Route::prefix('admin')->group(function() {
@@ -73,7 +77,6 @@ Route::middleware(['auth:users', 'token.type:access', 'approve:users'])->group(f
         Route::patch('/privilege', [AdminController::class, 'privilege'])->name('admin.privilege.update');
         Route::get('/privilege', PrivilegeController::class)->name('admin.privilege.list');
         Route::patch('/approve', [AdminController::class, 'approveRegistration'])->name('admin.approve');
-        Route::patch('/', [AdminController::class, 'updateProfile'])->name('admin.update');
         Route::get('/list', [AdminController::class, 'adminList'])->name('admin.list');
         Route::delete('/',[AdminController::class, 'unregister'])->name('admin.unregister');
         Route::delete('/master/{id}', [AdminController::class, 'unregisterMaster'])->name('admin.master.unregister');
@@ -84,7 +87,6 @@ Route::middleware(['auth:users', 'token.type:access', 'approve:users'])->group(f
         Route::get('/qr', [QRController::class, 'generator'])->name('qr');
         Route::delete('/',[UserController::class, 'unregister'])->name('user.unregister');
         Route::post('/logout', [UserController::class, 'logout'])  ->name('user.logout');
-        Route::patch('/' , [UserController::class, 'update'])->name('user.update');
         Route::patch('/approve', [UserController::class, 'approveRegistration'])->name('user.approve');
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ Route::prefix('admin')->group(function () {
 });
 
 // 이메일 타입의 토큰도 허용함
-Route::patch('/user/recover' , [UserController::class, 'recoverPassword'])
+Route::patch('/user/password' , [UserController::class, 'recoverPassword'])
     ->name('user.update')->middleware(['auth:users', 'token.type:email']);
 
 // 토큰 필요

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1549,7 +1549,7 @@
                 ],
                 "summary": "개인정보 수정",
                 "description": "관리자 개인정보 수정 시 사용합니다.",
-                "operationId": "c2d73bf06e181007910988b0f079736f",
+                "operationId": "2855115d6bc9cd15557fd4d715221961",
                 "requestBody": {
                     "description": "수정할 관리자 정보",
                     "required": true,
@@ -2439,6 +2439,48 @@
                     },
                     "500": {
                         "description": "ServerError"
+                    }
+                }
+            }
+        },
+        "/api/user/password": {
+            "patch": {
+                "tags": [
+                    "학생"
+                ],
+                "summary": "비밀번호 재설정",
+                "description": "유저의 비밀번호 재설정 시 사용합니다.",
+                "operationId": "a99eeb982e343cc05a2eedefe7af6337",
+                "requestBody": {
+                    "description": "수정할 유저의 비밀번호",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "password": {
+                                        "description": "변경할 비밀번호",
+                                        "type": "string",
+                                        "example": "asdf123"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "404": {
+                        "description": "ModelNotFoundException"
+                    },
+                    "422": {
+                        "description": "ValidationException"
+                    },
+                    "500": {
+                        "description": "Server Error"
                     }
                 }
             }


### PR DESCRIPTION
## 📣 연관된 이슈
> #55 


## 📝 작업 내용
> 한국어
1. 토큰을 생성하는 서비스 로직에서 타입을 매개변수로 받아 처리하도록 개선하였습니다.
2. 비밀번호 재설정 코드 발급 시, 비밀번호 재설정 토큰을 발급하도록 구현하였습니다.
3. 비밀번호 재설정을 위한 API를 구현하였습니다.
4. API 문서를 수정하였습니다.
5. AS상태 변경 기능의 에러를 해결하였습니다. 


> 일본어
1. トークンを生成するサービスロジックで、タイプをパラメータとして受け取り処理するように改善しました。
2. パスワードリセットコードの発行時に、パスワードリセットトークンを発行するように実装しました。
3. パスワードリセットのためのAPIを実装しました。
4. APIドキュメントを修正しました。
5. ASの状態変更機能のエラーを解決しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

