### PR TITLE
Fix: 管理者検索エラーを解決

### DIFF
--- a/app/Http/Controllers/Auth/AdminController.php
+++ b/app/Http/Controllers/Auth/AdminController.php
@@ -588,13 +588,13 @@ class AdminController extends Controller
             return response()->json(['error'=>$errorMessage], $errorStatus);
         }
 
-        $admins = User::has('privileges')->where('admin', true)->get();
+        $admins = User::where('admin', true)->get();
 
         if(isset($validated['type'])) {
             if($validated['type'] == 'unapproved') {
-                $admins = $admins->where('approved', '=', false)->values();
+                $admins = $admins->where('approved', false);
             } else if($validated['type'] == 'approved') {
-                $admins = $admins->where('approved','=', true)->values();
+                $admins = $admins->where('approved', true);
             }
         }
 


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 관리자 검색시, 권한이 없는 관리자는 검색이 되지 않는 문제를 해결하였습니다.


> 일본어
1. 管理者を検索するとき、権限を持ってない管理者は検索できない問題を解決しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

