### PR TITLE
Fix: 美容室の権限エラーを解決

### DIFF
--- a/app/Http/Controllers/MeetingRoom/MeetingRoomController.php
+++ b/app/Http/Controllers/MeetingRoom/MeetingRoomController.php
@@ -67,7 +67,7 @@ class MeetingRoomController extends Controller
 
         try {
             $validated = $request->validate([
-                'room_number' => 'required|numeric',
+                'room_number' => 'required|numeric|unique:meeting_rooms,room_number',
             ]);
         } catch (ValidationException $exception) {
             $errorStatus = $exception->status;

--- a/app/Policies/SalonPolicy.php
+++ b/app/Policies/SalonPolicy.php
@@ -11,6 +11,6 @@ class SalonPolicy
      */
     public function salon(User $admin): bool
     {
-        return $admin->admin && $admin->privileges()->where('privilege', 'admin')->exists();
+        return $admin->admin && $admin->privileges()->where('privilege', 'salon')->exists();
     }
 }


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 미용실 상태 업데이트 시 권한 설정 부분 오타 수정하였습니다.
2. 회의실 추가 기능 유효성 검사 규칙에 중복값을 허용하지 않도록 수정하였습니다.


> 일본어
1. 美容室の状態更新時の権限設定部分のタイプミスを修正しました。
2. 会議室追加機能のバリデーションルールで、重複値を許可しないように修正しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

