### PR TITLE
Fix: routeのnameエラーを解決

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -66,7 +66,7 @@ Route::prefix('admin')->group(function () {
 
 // 이메일 타입의 토큰도 허용함
 Route::patch('/user/password' , [UserController::class, 'recoverPassword'])
-    ->name('user.update')->middleware(['auth:users', 'token.type:email']);
+    ->name('user.update.password')->middleware(['auth:users', 'token.type:email']);
 
 // 토큰 필요
 Route::middleware(['auth:users', 'token.type:access', 'approve:users'])->group(function () {


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 중복된 라우트명으로 인해 발생하는 도커 이미지 빌드 에러를 해결하였습니다.


> 일본어
1. 重複したルート名によるDockerイメージのビルドエラーを解決しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

