### PR TITLE
Fix: notice作成エラーを解決

### DIFF
--- a/app/Models/Notice.php
+++ b/app/Models/Notice.php
@@ -14,6 +14,7 @@ class Notice extends Model
         'title',
         'content',
         'tag',
+        'urgent',
     ];
 
     public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 공지사항 작성 시, 모델 fillable 값에 urgent 속성 미할당으로 인해 긴급 공지가 작성되지 않는 문제를 해결하였습니다.


> 일본어
1. お知らせの作成時に、モデルのfillable値にurgent属性が割り当てられていないため、緊急のお知らせが作成されない問題を解決しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

