### PR TITLE
Fix: クエリエラーを解決

### DIFF
--- a/app/Http/Controllers/Administrator/AbsenceController.php
+++ b/app/Http/Controllers/Administrator/AbsenceController.php
@@ -197,9 +197,9 @@ class AbsenceController extends Controller
         $validated['user_id'] = auth('users')->id();
 
         $absenceList = AbsenceList::where('user_id', $validated['user_id'])
-            ->whereBetween('start_date', [$validated['start_date'], $validated['end_date']])
-            ->orWhere(function ($query) use ($validated) {
-                $query->whereBetween('end_date', [$validated['start_date'], $validated['end_date']]);
+            ->where(function ($query) use ($validated) {
+                $query->whereBetween('start_date', [$validated['start_date'], $validated['end_date']])
+                    ->orWhereBetween('end_date', [$validated['start_date'], $validated['end_date']]);
             })->exists();
 
         if($absenceList) {

--- a/app/Http/Controllers/Administrator/NoticeController.php
+++ b/app/Http/Controllers/Administrator/NoticeController.php
@@ -122,7 +122,7 @@ class NoticeController extends Controller
      */
     public function recentUrgent(): \Illuminate\Http\JsonResponse
     {
-        $notice = Notice::with('noticeImages')->whereIn('tag', ['bus', 'admin'])->latest()->first();
+        $notice = Notice::with('noticeImages')->latest()->first();
         return response()->json(['notices' => $notice]);
     }
 


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 외박/외출 신청 시 중복되는 예약을 찾는 쿼리 수정
2. 최근 공지사항 1건을 반환하는 기능에서, 모든 태그를 기준으로 검색하도록 수정


> 일본어
1. 外泊/外出申請の時、日程が重なる予約を探すクエリを修正
2. 最新のnoticeを読み込む機能で、全てのタグから検索するように修正


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

