### PR TITLE
Fix: refreshエラーを解決

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -18,6 +18,11 @@ class Authenticate extends Middleware
      */
     public function handle($request, $next, ...$guards): mixed
     {
+        if($request->cookie('refresh_token') !== null &&
+            $this->auth->setToken($request->cookie('refresh_token'))->check()) {
+            return $next($request);
+        }
+
         foreach ($guards as $guard) {
             if ($this->auth->guard($guard)->check()) {
                 return $next($request);


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. refresh token 인증 시 쿠키의 값을 읽어오지 못하는 문제 해결


> 일본어
1. refresh_token 認証の時、クッキーの値を読み込めない問題を解決


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

