### PR TITLE
Refactor: パスワードリセット機能のHTTPメソッドを変更

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,7 @@ Route::get('/healthy', function () {
 });
 
 /** 비밀번호 초기화 관련 */
-Route::get('/reset-password/verify', [PasswordResetCodeController::class, 'verifyPasswordResetCode'])->name('pw.reset.verify');
+Route::post('/reset-password/verify', [PasswordResetCodeController::class, 'verifyPasswordResetCode'])->name('pw.reset.verify');
 Route::post('/reset-password', [PasswordResetCodeController::class, 'sendPasswordResetCode'])->name('pw.reset.send');
 Route::patch('/reset-password' , [PasswordResetCodeController::class, 'resetPassword'])
     ->name('pw.reset')->middleware(['auth:users', 'token.type:email']);// 이메일 타입의 토큰도 허용함


### PR DESCRIPTION
## 📣 연관된 이슈
> X


## 📝 작업 내용
> 한국어
1. 패스워드 초기화 로직의 HTTP 메서드를 GET에서 POST로 변경했습니다.


> 일본어
1. パスワードリセット機能のHTTPメソッドをGETからPOSTに変更しました。


## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

